### PR TITLE
Eradicate empty link issue

### DIFF
--- a/lib/Map/Tube.pm
+++ b/lib/Map/Tube.pm
@@ -1,6 +1,6 @@
 package Map::Tube;
 
-$Map::Tube::VERSION   = '4.03';
+$Map::Tube::VERSION   = '4.04';
 $Map::Tube::AUTHORITY = 'cpan:MANWAR';
 
 =head1 NAME
@@ -75,10 +75,10 @@ documented in L<Map::Tube::Cookbook>.
     |                      |          | Sofia, Tbilisi, Vienna, Warsaw,          |
     |                      |          | Yekaterinburg                            |
     |                      |          |                                          |
-    | Gisbert W Selke      | GWS      | 14 (Beijing, Brussels, Chicago, Glasgow, |
+    | Gisbert W Selke      | GWS      | 15 (Beijing, Brussels, Chicago, Glasgow, |
     |                      |          | Hamburg, KoelnBonn, Lyon, Muenchen,      |
-    |                      |          | Napoli, Oslo, Rhein/Ruhr, Stockholm,     |
-    |                      |          | Stuttgart, Toulouse)                     |
+    |                      |          | Napoli, Oslo, Rhein/Ruhr, San Francisco, |
+    |                      |          | Stockholm, Stuttgart, Toulouse)          |
     |                      |          |                                          |
     | Mohammad Sajid Anwar | MANWAR   | 7 (Barcelona, Delhi, Kolkatta, London,   |
     |                      |          | Madrid, NYC, Tokyo)                      |
@@ -816,16 +816,16 @@ sub _get_shortest_route {
             my $links = [ split /\,/, $f_node->{link} ];
             while (scalar(@$links) > 0) {
                 my ($success, $link) = $self->_get_next_link($from, $seen, $links);
-				# was: $success or ($links = [ grep(!/\b\Q$link\E\b/, @$links) ]) and next;
-				# was: next unless defined($link);	-> if this ever happens, we'll be stuck in an infinite loop
-				if (!$success) {
-					# If we didn't find any existing node at all, we're done:
-					last unless defined $link;
-					# Else: we found some node but it doesn't fit our needs; so remove it from
-					# the candidates and try the next one:
-					$links = [ grep(!/\b\Q$link\E\b/, @$links) ];
-					next;
-				}
+                # was: $success or ($links = [ grep(!/\b\Q$link\E\b/, @$links) ]) and next;
+                # was: next unless defined($link);  -> if this ever happens, we'll be stuck in an infinite loop
+                if (!$success) {
+                    # If we didn't find any existing node at all, we're done:
+                    last unless defined $link;
+                    # Else: we found some node but it doesn't fit our needs; so remove it from
+                    # the candidates and try the next one:
+                    $links = [ grep(!/\b\Q$link\E\b/, @$links) ];
+                    next;
+                }
 
                 if (($self->_get_length($link) == 0) || ($length > ($index + 1))) {
                     $self->_set_length($link, $length + 1);
@@ -995,7 +995,8 @@ sub _init_map {
                 push @link_nodes, (split /\|/, $_nodes);
             }
 
-            $station->{link} .= "," . join(",", @link_nodes);
+            $station->{link} .= "," if $station->{link} ne "";
+            $station->{link} .= join(",", @link_nodes);
         }
 
         $station->{line} = $_station_lines;
@@ -1119,7 +1120,7 @@ sub _get_next_link {
 
     my $link = undef;
     foreach my $_link (@$links) {
-		return (0, $_link) if ((exists $seen->{$_link}) || ($from eq $_link));
+        return (0, $_link) if ((exists $seen->{$_link}) || ($from eq $_link));
 
         my $node = $nodes->{$_link};
         next unless defined $node;
@@ -1133,7 +1134,7 @@ sub _get_next_link {
         $link = $_link;
     }
 
-	return (defined($link), $link);
+    return (defined($link), $link);
 }
 
 sub _set_active_links {


### PR DESCRIPTION
Turns out that the local fix for empty links entries was not good enough: M::T::Plugins::Graph also takes issue with this situation.
(Try "`map-tube --map=SanFrancisco --gen`" to see the issue come up.)
I propose to fix the problem at the root (which I should have suggested right away...), i.e., when filling the `{link}` field of a station, by changing this line (around line 1000 in Tube.pm)
`  $station->{link} .= "," . join(",", @link_nodes);`
into these two lines:
```
  $station->{link} .= "," if $station->{link} ne "";
  $station->{link} .= join(",", @link_nodes);
```

My apologies for the kludge I have offered before!

Also, enclosed is an update for the list of available maps (added San Francisco).
